### PR TITLE
Add realtime static scheduling example

### DIFF
--- a/firmware/Cargo.toml
+++ b/firmware/Cargo.toml
@@ -33,7 +33,12 @@ embedded-hal = "0.2.7"
 tm4c129x-hal = "0.9.2"
 panic-never = "0.1.0"
 static_assertions = "1.1.0"
-ufmt = "0.1.0"
+ufmt = "0.2.0"
 modular-bitfield = "0.11.2"
+
+# For ethernet example only
 catnip = "0.3.0"
 # catnip = { path="../../catnip", default_features=false }
+
+# For interrupt example only
+irq = "0.2.3"

--- a/firmware/examples/blink_systick.rs
+++ b/firmware/examples/blink_systick.rs
@@ -1,0 +1,143 @@
+//! A blinky-LED example application
+
+#![no_std]
+#![no_main]
+
+extern crate embedded_hal;
+extern crate tm4c129_launchpad;
+extern crate tm4c129x_hal;
+
+use cortex_m_rt::{exception, ExceptionFrame};
+use static_assertions::const_assert;
+
+use core::fmt::Write;
+
+use embedded_hal::blocking::delay::DelayMs;
+use embedded_hal::digital::v2::*; // GPIO set high/low
+use embedded_hal::serial::Read as ReadHal;
+use tm4c129_launchpad::board::{clocks, safe, Board};
+use tm4c129_launchpad::startup::{Interrupt};
+use tm4c129x_hal::gpio::GpioExt;
+use tm4c129x_hal::serial;
+use tm4c129x_hal::time::Bps;
+
+use irq::{handler, scope, scoped_interrupts};
+
+
+fn systick() {
+    use tm4c129x_hal::{gpio::GpioExt, serial, sysctl::SysctlExt, time::Bps, CorePeripherals};
+    let mut core_peripherals = unsafe { CorePeripherals::steal() };
+
+    core_peripherals.SYST.disable_interrupt();
+    core_peripherals.SYST.clear_current();
+
+    let p = unsafe { tm4c129x_hal::Peripherals::steal() };
+    let pins = p.GPIO_PORTF_AHB.split(&p.SYSCTL.constrain().power_control);
+
+    let mut delay = tm4c129x_hal::delay::Delay::new(core_peripherals.SYST, unsafe { &clocks() });
+    let mut led0 = pins.pf0.into_push_pull_output();
+    loop {
+        let _ = led0.set_high().unwrap_or_default();
+        delay.delay_ms(500u32);
+        let _ = led0.set_low().unwrap_or_default();
+        delay.delay_ms(500u32);
+    }
+}
+
+
+#[no_mangle]
+pub fn stellaris_main(mut board: Board) -> ! {
+    let mut pins_a = board.GPIO_PORTA_AHB.split(&board.power_control);
+    let mut uart = serial::Serial::uart0(
+        board.UART0,
+        pins_a.pa1.into_af_push_pull(&mut pins_a.control),
+        pins_a.pa0.into_af_push_pull(&mut pins_a.control),
+        (),
+        (),
+        Bps(115200),
+        serial::NewlineMode::SwapLFtoCRLF,
+        clocks(),
+        &board.power_control,
+    );
+
+    // let mut delay = tm4c129x_hal::delay::Delay::new(board.core_peripherals.SYST, clocks());
+
+    // Set up systick interrupt
+    //    Set timing duri
+    let us = 1000;
+    let mut rvr = us * (clocks().sysclk.0 / 1_000_000);
+    rvr += (us * ((clocks().sysclk.0 % 1_000_000) / 1_000)) / 1_000;
+    rvr += (us * (clocks().sysclk.0 % 1_000)) / 1_000_000;
+
+    &board.core_peripherals.SYST.set_reload(rvr);
+    &board.core_peripherals.SYST.clear_current();
+    &board.core_peripherals.SYST.enable_counter();
+    // let _ = &board.core_peripherals.ITM.
+    &board.core_peripherals.SYST.enable_interrupt();
+
+    writeln!(uart, "SysTick Blink {}", &board.core_peripherals.SYST.is_interrupt_enabled()).unwrap_or_default();
+
+    let mut loops = 0;
+
+    // handler!(
+    //     systick = || {
+    //         // Spam serial
+    //         writeln!(uart, "Hello, world! Loops = {}", loops).unwrap_or_default();
+    //         while let Ok(ch) = uart.read() {
+    //             // Echo
+    //             writeln!(uart, "byte read {}", ch).unwrap_or_default();
+    //         }
+
+    //         loops = loops + 1;
+
+    //         if *(&(board.button0).is_low().unwrap_or_default()) {
+    //             // Turn all the LEDs on
+    //             let _ = &(board.led0).set_high().unwrap_or_default();
+    //             let _ = &(board.led1).set_high().unwrap_or_default();
+    //             let _ = &(board.led2).set_high().unwrap_or_default();
+    //             let _ = &(board.led3).set_high().unwrap_or_default();
+    //         } else {
+    //             let which_led = loops % 4;
+
+    //             // Turn all the LEDs off
+    //             let _ = &(board.led0).set_low().unwrap_or_default();
+    //             let _ = &(board.led1).set_low().unwrap_or_default();
+    //             let _ = &(board.led2).set_low().unwrap_or_default();
+    //             let _ = &(board.led3).set_low().unwrap_or_default();
+
+    //             // Turn on just the selected LED
+    //             match which_led {
+    //                 0 => {
+    //                     let _ = &(board.led1).set_high().unwrap_or_default();
+    //                 }
+    //                 1 => {
+    //                     let _ = &(board.led1).set_high().unwrap_or_default();
+    //                 }
+    //                 2 => {
+    //                     let _ = &(board.led2).set_high().unwrap_or_default();
+    //                 }
+    //                 3 => {
+    //                     let _ = &(board.led3).set_high().unwrap_or_default();
+    //                 },
+    //                 _ => {}
+    //             }
+    //         }
+    //     }
+    // );
+
+    // Create a scope and register the systick interrupt handler.
+    handler!(systick_handler = || systick());
+    scope(|s| {
+        s.register(Interrupt::SysTick, systick_handler);
+
+
+        loop {
+            // Wait for interrupt
+        }
+    });
+
+    // Must not return
+    loop {};
+
+
+}

--- a/firmware/examples/blink_systick.rs
+++ b/firmware/examples/blink_systick.rs
@@ -7,6 +7,7 @@ extern crate embedded_hal;
 extern crate tm4c129_launchpad;
 extern crate tm4c129x_hal;
 
+use cortex_m::peripheral::syst::SystClkSource;
 use cortex_m_rt::{exception, ExceptionFrame};
 use static_assertions::const_assert;
 
@@ -45,7 +46,8 @@ pub fn stellaris_main(mut board: Board) -> ! {
     let mut reload = us_per_interrupt * clock_cycles_per_us + 1; //  [cycles/interrupt] Interrupt after this many clock cycles
 
     //    Enable SysTick interrupt
-    board.core_peripherals.SYST.set_reload(reload);
+    board.core_peripherals.SYST.set_reload(120_000_000 / 1000);
+    board.core_peripherals.SYST.set_clock_source(SystClkSource::Core);  // Use sysclk
     board.core_peripherals.SYST.clear_current();
     board.core_peripherals.SYST.enable_counter();
     board.core_peripherals.SYST.enable_interrupt();

--- a/firmware/examples/blink_systick.rs
+++ b/firmware/examples/blink_systick.rs
@@ -16,34 +16,12 @@ use embedded_hal::blocking::delay::DelayMs;
 use embedded_hal::digital::v2::*; // GPIO set high/low
 use embedded_hal::serial::Read as ReadHal;
 use tm4c129_launchpad::board::{clocks, safe, Board};
-use tm4c129_launchpad::startup::{Interrupt};
+use tm4c129_launchpad::startup::Interrupt;
 use tm4c129x_hal::gpio::GpioExt;
 use tm4c129x_hal::serial;
 use tm4c129x_hal::time::Bps;
 
 use irq::{handler, scope, scoped_interrupts};
-
-
-fn systick() {
-    use tm4c129x_hal::{gpio::GpioExt, serial, sysctl::SysctlExt, time::Bps, CorePeripherals};
-    let mut core_peripherals = unsafe { CorePeripherals::steal() };
-
-    core_peripherals.SYST.disable_interrupt();
-    core_peripherals.SYST.clear_current();
-
-    let p = unsafe { tm4c129x_hal::Peripherals::steal() };
-    let pins = p.GPIO_PORTF_AHB.split(&p.SYSCTL.constrain().power_control);
-
-    let mut delay = tm4c129x_hal::delay::Delay::new(core_peripherals.SYST, unsafe { &clocks() });
-    let mut led0 = pins.pf0.into_push_pull_output();
-    loop {
-        let _ = led0.set_high().unwrap_or_default();
-        delay.delay_ms(500u32);
-        let _ = led0.set_low().unwrap_or_default();
-        delay.delay_ms(500u32);
-    }
-}
-
 
 #[no_mangle]
 pub fn stellaris_main(mut board: Board) -> ! {
@@ -60,84 +38,86 @@ pub fn stellaris_main(mut board: Board) -> ! {
         &board.power_control,
     );
 
-    // let mut delay = tm4c129x_hal::delay::Delay::new(board.core_peripherals.SYST, clocks());
+    // Set up systick as static scheduling interrupt
+    //    Set tick timing
+    let us = 100; // How many us per tick?
+    let mut reload = us * (clocks().sysclk.0 / 1_000_000) + 1;  // Interrupt after this many clock cycles
+    //    Enable SysTick interrupt
+    board.core_peripherals.SYST.set_reload(reload);
+    board.core_peripherals.SYST.clear_current();
+    board.core_peripherals.SYST.enable_counter();
+    board.core_peripherals.SYST.enable_interrupt();
 
-    // Set up systick interrupt
-    //    Set timing duri
-    let us = 1000;
-    let mut rvr = us * (clocks().sysclk.0 / 1_000_000);
-    rvr += (us * ((clocks().sysclk.0 % 1_000_000) / 1_000)) / 1_000;
-    rvr += (us * (clocks().sysclk.0 % 1_000)) / 1_000_000;
+    writeln!(
+        uart,
+        "SysTick Blink {}",
+        board.core_peripherals.SYST.is_interrupt_enabled()
+    )
+    .unwrap_or_default();
 
-    &board.core_peripherals.SYST.set_reload(rvr);
-    &board.core_peripherals.SYST.clear_current();
-    &board.core_peripherals.SYST.enable_counter();
-    // let _ = &board.core_peripherals.ITM.
-    &board.core_peripherals.SYST.enable_interrupt();
+    let mut ticks: u64 = 0;
+    let mut loops: u8 = 0;
 
-    writeln!(uart, "SysTick Blink {}", &board.core_peripherals.SYST.is_interrupt_enabled()).unwrap_or_default();
+    handler!(
+        systick_handler = || {
+            ticks = ticks.wrapping_add(1);
 
-    let mut loops = 0;
+            if ticks % 100 == 0 {  // Cycle LEDs once every hundred systicks
+                loops = loops.wrapping_add(1);
 
-    // handler!(
-    //     systick = || {
-    //         // Spam serial
-    //         writeln!(uart, "Hello, world! Loops = {}", loops).unwrap_or_default();
-    //         while let Ok(ch) = uart.read() {
-    //             // Echo
-    //             writeln!(uart, "byte read {}", ch).unwrap_or_default();
-    //         }
+                // Spam serial
+                writeln!(uart, "Hello, world! Ticks = {}; Loops = {}", ticks, loops).unwrap_or_default();
+                while let Ok(ch) = uart.read() {
+                    // Echo
+                    writeln!(uart, "byte read {}", ch).unwrap_or_default();
+                }
 
-    //         loops = loops + 1;
+                if *(&(board.button0).is_low().unwrap_or_default()) {
+                    // Turn all the LEDs on
+                    let _ = &(board.led0).set_high().unwrap_or_default();
+                    let _ = &(board.led1).set_high().unwrap_or_default();
+                    let _ = &(board.led2).set_high().unwrap_or_default();
+                    let _ = &(board.led3).set_high().unwrap_or_default();
+                } else {
+                    let which_led = loops % 4;
 
-    //         if *(&(board.button0).is_low().unwrap_or_default()) {
-    //             // Turn all the LEDs on
-    //             let _ = &(board.led0).set_high().unwrap_or_default();
-    //             let _ = &(board.led1).set_high().unwrap_or_default();
-    //             let _ = &(board.led2).set_high().unwrap_or_default();
-    //             let _ = &(board.led3).set_high().unwrap_or_default();
-    //         } else {
-    //             let which_led = loops % 4;
+                    // Turn all the LEDs off
+                    let _ = &(board.led0).set_low().unwrap_or_default();
+                    let _ = &(board.led1).set_low().unwrap_or_default();
+                    let _ = &(board.led2).set_low().unwrap_or_default();
+                    let _ = &(board.led3).set_low().unwrap_or_default();
 
-    //             // Turn all the LEDs off
-    //             let _ = &(board.led0).set_low().unwrap_or_default();
-    //             let _ = &(board.led1).set_low().unwrap_or_default();
-    //             let _ = &(board.led2).set_low().unwrap_or_default();
-    //             let _ = &(board.led3).set_low().unwrap_or_default();
-
-    //             // Turn on just the selected LED
-    //             match which_led {
-    //                 0 => {
-    //                     let _ = &(board.led1).set_high().unwrap_or_default();
-    //                 }
-    //                 1 => {
-    //                     let _ = &(board.led1).set_high().unwrap_or_default();
-    //                 }
-    //                 2 => {
-    //                     let _ = &(board.led2).set_high().unwrap_or_default();
-    //                 }
-    //                 3 => {
-    //                     let _ = &(board.led3).set_high().unwrap_or_default();
-    //                 },
-    //                 _ => {}
-    //             }
-    //         }
-    //     }
-    // );
+                    // Turn on just the selected LED
+                    match which_led {
+                        0 => {
+                            let _ = &(board.led0).set_high();
+                        }
+                        1 => {
+                            let _ = &(board.led1).set_high();
+                        }
+                        2 => {
+                            let _ = &(board.led2).set_high();
+                        }
+                        3 => {
+                            let _ = &(board.led3).set_high();
+                        }
+                        _ => {}
+                    }
+                }
+            }
+        }
+    );
 
     // Create a scope and register the systick interrupt handler.
-    handler!(systick_handler = || systick());
+    // handler!(systick_handler = || systick());
     scope(|s| {
         s.register(Interrupt::SysTick, systick_handler);
-
 
         loop {
             // Wait for interrupt
         }
     });
 
-    // Must not return
-    loop {};
-
-
+    // Main must not return
+    loop {}
 }

--- a/firmware/examples/blink_systick.rs
+++ b/firmware/examples/blink_systick.rs
@@ -44,8 +44,8 @@ pub fn stellaris_main(mut board: Board) -> ! {
     let us_per_interrupt = 1000; // [us] How many us per interrupt?
     let clock_cycles_per_us = clocks().sysclk.0 / 1_000_000; // [cycles]
     let mut reload = us_per_interrupt * clock_cycles_per_us + 1; //  [cycles/interrupt] Interrupt after this many clock cycles
-
-    //    Enable SysTick interrupt
+    
+    //    Configure and enable SysTick interrupt
     board.core_peripherals.SYST.set_reload(120_000_000 / 1000);
     board.core_peripherals.SYST.set_clock_source(SystClkSource::Core);  // Use sysclk
     board.core_peripherals.SYST.clear_current();

--- a/firmware/examples/flash.sh
+++ b/firmware/examples/flash.sh
@@ -9,5 +9,7 @@ cargo build --example $1 --release  &&
 arm-none-eabi-objcopy -O binary $INFILE $OUTFILE  &&
 # Show binary size
 ls -lh $OUTFILE &&
+# Unlock just in case
+# sudo $LM4FLASH -U
 # Flash
 sudo $LM4FLASH $OUTFILE

--- a/firmware/src/board.rs
+++ b/firmware/src/board.rs
@@ -365,7 +365,7 @@ pub fn safe() -> ! {
     let pins = p.GPIO_PORTF_AHB.split(&p.SYSCTL.constrain().power_control);
 
     let mut delay = tm4c129x_hal::delay::Delay::new(core_peripherals.SYST, unsafe { &CLOCKS });
-    let mut led0 = pins.pf1.into_push_pull_output();
+    let mut led0 = pins.pf0.into_push_pull_output();
     loop {
         let _ = led0.set_high().unwrap_or_default();
         delay.delay_ms(200u32);

--- a/firmware/src/board.rs
+++ b/firmware/src/board.rs
@@ -187,6 +187,7 @@ pub struct Board {
 }
 
 /// Clock speed defaults
+/// These are overridden with as-configured values during sysctl.clock_setup.freeze()
 static mut CLOCKS: Clocks = Clocks {
     osc: Hertz(25_000_000),
     sysclk: Hertz(120_000_000),


### PR DESCRIPTION
* Add dep on irq crate for scoped interrupts
* Add capability to preempt SysTick, PendSV, and SVCall exception handlers with scoped interrupts
* Fix LED pin number in board::safe()
* Add blink_systick example showing static scheduling using scoped SysTick interrupt